### PR TITLE
fix(fabric.mod.json): allow using higher version fabric api

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=net.snackbag.coinsarise
 archives_base_name=coins_arise
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,7 +37,7 @@
 		"fabricloader": ">=0.15.11",
 		"minecraft": "1.20.1",
 		"java": ">=17",
-		"fabric-api": "0.92.1+1.20.1"
+		"fabric-api": ">=0.92.1+1.20.1"
 	},
 	"suggests": {
 		"another-mod": "*"


### PR DESCRIPTION
Previously when trying to use this mod on 0.92.2 fabric api it crashed saying that it needs 0.92.1. I fixed this by adding >=. simple fix